### PR TITLE
fix: use dedicated GHCR image names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
             NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
             NEXT_PUBLIC_SPEAKING_USE_LOCAL_TOKEN_ROUTE=${{ secrets.NEXT_PUBLIC_SPEAKING_USE_LOCAL_TOKEN_ROUTE }}
           tags: |
-            ghcr.io/ziiyodullayevv/mock4ielts:latest
-            ghcr.io/ziiyodullayevv/mock4ielts:${{ github.sha }}
+            ghcr.io/ziiyodullayevv/mock4ielts-web:latest
+            ghcr.io/ziiyodullayevv/mock4ielts-web:${{ github.sha }}
 
   docker-admin:
     name: docker-admin
@@ -117,5 +117,5 @@ jobs:
             NEXT_PUBLIC_SERVER_URL=${{ secrets.NEXT_PUBLIC_SERVER_URL }}
             NEXT_PUBLIC_ASSETS_DIR=${{ secrets.NEXT_PUBLIC_ASSETS_DIR }}
           tags: |
-            ghcr.io/ziiyodullayevv/mock4ielts-admin-panel:latest
-            ghcr.io/ziiyodullayevv/mock4ielts-admin-panel:${{ github.sha }}
+            ghcr.io/ziiyodullayevv/mock4ielts-admin:latest
+            ghcr.io/ziiyodullayevv/mock4ielts-admin:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ npm run admin:build
 
 ## Deployment
 
-The web app builds the `ghcr.io/ziiyodullayevv/mock4ielts` image.
-The admin app builds the `ghcr.io/ziiyodullayevv/mock4ielts-admin-panel` image.
+The web app builds the `ghcr.io/ziiyodullayevv/mock4ielts-web` image.
+The admin app builds the `ghcr.io/ziiyodullayevv/mock4ielts-admin` image.
 
 The GitHub Actions workflow validates both apps and publishes both images on
 successful pushes to `main`.

--- a/apps/admin/docker-compose.yml
+++ b/apps/admin/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   admin:
-    image: ghcr.io/ziiyodullayevv/mock4ielts-admin-panel:latest
+    image: ghcr.io/ziiyodullayevv/mock4ielts-admin:latest
     container_name: mock4ielts-admin
     restart: unless-stopped
     ports:

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     #     NEXT_PUBLIC_ASSETS_DIR: ${NEXT_PUBLIC_ASSETS_DIR:-}
     #     NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${NEXT_PUBLIC_GOOGLE_CLIENT_ID:-}
     #     NEXT_PUBLIC_SPEAKING_USE_LOCAL_TOKEN_ROUTE: ${NEXT_PUBLIC_SPEAKING_USE_LOCAL_TOKEN_ROUTE:-}
-    image: ghcr.io/ziiyodullayevv/mock4ielts:latest
+    image: ghcr.io/ziiyodullayevv/mock4ielts-web:latest
     container_name: mock4ielts
     restart: unless-stopped
     ports:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,8 +160,8 @@ The full API contract is documented in [api.md](./api.md).
 
 The monorepo builds two independent images:
 
-- web: `ghcr.io/ziiyodullayevv/mock4ielts`
-- admin: `ghcr.io/ziiyodullayevv/mock4ielts-admin-panel`
+- web: `ghcr.io/ziiyodullayevv/mock4ielts-web`
+- admin: `ghcr.io/ziiyodullayevv/mock4ielts-admin`
 
 GitHub Actions validates both apps on pull requests into `main`. On pushes to
 `main`, CI also builds and pushes both images. CD deploys the images to the VPS:

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -15,8 +15,8 @@ Required PR checks:
 
 On pushes to `main`, the workflow also builds and pushes:
 
-- `ghcr.io/ziiyodullayevv/mock4ielts`
-- `ghcr.io/ziiyodullayevv/mock4ielts-admin-panel`
+- `ghcr.io/ziiyodullayevv/mock4ielts-web`
+- `ghcr.io/ziiyodullayevv/mock4ielts-admin`
 
 Build contexts:
 


### PR DESCRIPTION
## Summary
- use dedicated GHCR package names for web and admin images
- update Docker Compose references to match published images
- align CI/CD and architecture docs with the new image names

## Validation
- git diff --check

## Context
The main CI build passed after PR #8 was merged, but both Docker publish jobs failed at GHCR push with permission_denied: write_package for the previous package names.