### PR TITLE
Hide contests temporarily

### DIFF
--- a/apps/web/src/app/(main)/contest/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/contest/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 
+import { redirect } from 'next/navigation';
 import { paths } from '@/src/routes/paths';
+import { FEATURES } from '@/src/lib/features';
 import { buildPageMetadata } from '@/src/lib/metadata';
 import { ContestDetailView } from '@/src/sections/contest/view';
 
@@ -22,6 +24,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function Page({ params }: PageProps) {
   const { slug } = await params;
+
+  if (!FEATURES.contests) {
+    redirect(paths.mockExam.root);
+  }
 
   return <ContestDetailView contestId={slug} />;
 }

--- a/apps/web/src/app/(main)/contest/page.tsx
+++ b/apps/web/src/app/(main)/contest/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next';
 
+import { redirect } from 'next/navigation';
+import { paths } from '@/src/routes/paths';
+import { FEATURES } from '@/src/lib/features';
 import { ContestView } from '@/sections/contest/view';
 import { buildPageMetadata } from '@/src/lib/metadata';
 
@@ -11,5 +14,9 @@ export const metadata: Metadata = buildPageMetadata({
 });
 
 export default function Page() {
+  if (!FEATURES.contests) {
+    redirect(paths.mockExam.root);
+  }
+
   return <ContestView />;
 }

--- a/apps/web/src/layouts/nav-config-main.tsx
+++ b/apps/web/src/layouts/nav-config-main.tsx
@@ -1,4 +1,5 @@
 import { paths } from '@/src/routes/paths';
+import { FEATURES } from '@/src/lib/features';
 
 type HeaderPanelItem = {
   href: string;
@@ -43,4 +44,4 @@ export const HEADER_ITEMS: HeaderItem[] = [
     label: 'Contest',
     matchPaths: [paths.contest.root],
   },
-];
+].filter((item) => FEATURES.contests || item.id !== 'contest');

--- a/apps/web/src/lib/features.ts
+++ b/apps/web/src/lib/features.ts
@@ -1,0 +1,3 @@
+export const FEATURES = {
+  contests: false,
+} as const;


### PR DESCRIPTION
## Summary
- add a small web feature flag for contests
- hide Contest from the public header navigation
- redirect /contest and /contest/[slug] to /mock-exams while contests are disabled

## Verification
- npm run lint --workspace not used; ran in apps/web: npm run lint
- apps/web: npm run build
- yarn --cwd apps/admin lint
- yarn --cwd apps/admin build