### PR TITLE
Fix production image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
             NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
             NEXT_PUBLIC_SPEAKING_USE_LOCAL_TOKEN_ROUTE=${{ secrets.NEXT_PUBLIC_SPEAKING_USE_LOCAL_TOKEN_ROUTE }}
           tags: |
+            ghcr.io/ziiyodullayevv/mock4ielts:latest
             ghcr.io/ziiyodullayevv/mock4ielts-web:latest
             ghcr.io/ziiyodullayevv/mock4ielts-web:${{ github.sha }}
 
@@ -117,5 +118,6 @@ jobs:
             NEXT_PUBLIC_SERVER_URL=${{ secrets.NEXT_PUBLIC_SERVER_URL }}
             NEXT_PUBLIC_ASSETS_DIR=${{ secrets.NEXT_PUBLIC_ASSETS_DIR }}
           tags: |
+            ghcr.io/ziiyodullayevv/mock4ielts-admin-panel:latest
             ghcr.io/ziiyodullayevv/mock4ielts-admin:latest
             ghcr.io/ziiyodullayevv/mock4ielts-admin:${{ github.sha }}


### PR DESCRIPTION
## Summary
- push the web image tag used by the production server compose
- push the admin image tag used by the production server compose

## Why
The server currently pulls ghcr.io/ziiyodullayevv/mock4ielts:latest and ghcr.io/ziiyodullayevv/mock4ielts-admin-panel:latest, while CI only pushed the newer mock4ielts-web/mock4ielts-admin tags.