### PR TITLE
Migrate production compose image names during deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,6 +51,7 @@ jobs:
               echo "NEXT_PUBLIC_GOOGLE_CLIENT_ID=$NEXT_PUBLIC_GOOGLE_CLIENT_ID"
               echo "NEXT_PUBLIC_SPEAKING_USE_LOCAL_TOKEN_ROUTE=$NEXT_PUBLIC_SPEAKING_USE_LOCAL_TOKEN_ROUTE"
             } > .env
+            sed -i 's#ghcr.io/ziiyodullayevv/mock4ielts:latest#ghcr.io/ziiyodullayevv/mock4ielts-web:latest#g' docker-compose.yml compose.yml 2>/dev/null || true
             docker compose pull
             docker compose up -d --force-recreate
             docker image prune -f
@@ -76,6 +77,7 @@ jobs:
           key: ${{ secrets.VPS_SSH_KEY || secrets.SSH_PRIVATE_KEY }}
           script: |
             cd /opt/mock4ielts-admin
+            sed -i 's#ghcr.io/ziiyodullayevv/mock4ielts-admin-panel:latest#ghcr.io/ziiyodullayevv/mock4ielts-admin:latest#g' docker-compose.yml compose.yml 2>/dev/null || true
             docker compose pull
             docker compose up -d --force-recreate
             docker image prune -f

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,6 @@ jobs:
             NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
             NEXT_PUBLIC_SPEAKING_USE_LOCAL_TOKEN_ROUTE=${{ secrets.NEXT_PUBLIC_SPEAKING_USE_LOCAL_TOKEN_ROUTE }}
           tags: |
-            ghcr.io/ziiyodullayevv/mock4ielts:latest
             ghcr.io/ziiyodullayevv/mock4ielts-web:latest
             ghcr.io/ziiyodullayevv/mock4ielts-web:${{ github.sha }}
 
@@ -118,6 +117,5 @@ jobs:
             NEXT_PUBLIC_SERVER_URL=${{ secrets.NEXT_PUBLIC_SERVER_URL }}
             NEXT_PUBLIC_ASSETS_DIR=${{ secrets.NEXT_PUBLIC_ASSETS_DIR }}
           tags: |
-            ghcr.io/ziiyodullayevv/mock4ielts-admin-panel:latest
             ghcr.io/ziiyodullayevv/mock4ielts-admin:latest
             ghcr.io/ziiyodullayevv/mock4ielts-admin:${{ github.sha }}


### PR DESCRIPTION
## Summary
- keep CI pushing the GHCR packages it can write to
- update production compose image names during CD before docker compose pull

## Verification
- previous main CI failed because GITHUB_TOKEN could not write old GHCR package names
- this keeps the successful package names and migrates the server compose references