### PR TITLE
Redirect contest routes while disabled

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,6 +6,20 @@ const nextConfig: NextConfig = {
   reactStrictMode: false,
   trailingSlash: true,
   output: isStaticExport ? 'export' : 'standalone',
+  async redirects() {
+    return [
+      {
+        source: '/contest',
+        destination: '/mock-exams',
+        permanent: false,
+      },
+      {
+        source: '/contest/:path*',
+        destination: '/mock-exams',
+        permanent: false,
+      },
+    ];
+  },
   env: {
     BUILD_STATIC_EXPORT: JSON.stringify(isStaticExport),
   },


### PR DESCRIPTION
## Summary
- add Next.js redirects for /contest and /contest/* to /mock-exams
- keeps contest hidden at HTTP routing level while the feature flag is off

## Verification
- apps/web: npm run build